### PR TITLE
fix bug for bitcast when vector scalar size is smaller than 8

### DIFF
--- a/lib/CodeGen/SelectionDAG/LegalizeIntegerTypes.cpp
+++ b/lib/CodeGen/SelectionDAG/LegalizeIntegerTypes.cpp
@@ -256,6 +256,32 @@ SDValue DAGTypeLegalizer::PromoteIntRes_BITCAST(SDNode *N) {
       return DAG.getNode(ISD::BITCAST, dl, NOutVT, GetWidenedVector(InOp));
   }
 
+  // If vector scalar type is smaller than i8, we cannot use store and load
+  // to implement bitcast directly, first cast the input to integer type,
+  // then use store and load.
+  EVT InSclType = InVT.getScalarType();
+  unsigned ScalarSize = InSclType.getSizeInBits();
+  if (ScalarSize < 8) {
+    unsigned ElemNum = InVT.getVectorNumElements();
+    EVT ResultType = EVT::getIntegerVT(*DAG.getContext(), InVT.getSizeInBits());
+    EVT IntegerType = TLI.getVectorIdxTy();
+    SDValue Result = DAG.getNode(ISD::EXTRACT_VECTOR_ELT, dl,
+                                 InSclType, InOp, DAG.getConstant(0, IntegerType));
+    Result = DAG.getNode(ISD::ZERO_EXTEND, dl, ResultType, Result);
+
+    for (unsigned Idx = 1; Idx < ElemNum; ++Idx) {
+      SDValue IdxNode = DAG.getConstant(Idx, IntegerType);
+      SDValue BitsToShift = DAG.getConstant(Idx*ScalarSize, IntegerType);
+      SDValue Element = DAG.getNode(ISD::ZERO_EXTEND, dl, ResultType,
+                                    DAG.getNode(ISD::EXTRACT_VECTOR_ELT,
+                                                dl, InSclType, InOp, IdxNode));
+      Result = DAG.getNode(ISD::OR, dl, ResultType, Result,
+                           DAG.getNode(ISD::SHL, dl, ResultType, Element, BitsToShift));
+    }
+
+    InOp = Result;
+  }
+
   return DAG.getNode(ISD::ANY_EXTEND, dl, NOutVT,
                      CreateStackStoreLoad(InOp, OutVT));
 }

--- a/lib/CodeGen/SelectionDAG/LegalizeIntegerTypes.cpp
+++ b/lib/CodeGen/SelectionDAG/LegalizeIntegerTypes.cpp
@@ -259,9 +259,9 @@ SDValue DAGTypeLegalizer::PromoteIntRes_BITCAST(SDNode *N) {
   // If vector scalar type is smaller than i8, we cannot use store and load
   // to implement bitcast directly, first cast the input to integer type,
   // then use store and load.
-  EVT InSclType = InVT.getScalarType();
-  unsigned ScalarSize = InSclType.getSizeInBits();
-  if (ScalarSize < 8) {
+  if (InVT.isVector() && InVT.getScalarType().getSizeInBits() < 8) {
+    EVT InSclType = InVT.getScalarType();
+    unsigned ScalarSize = InSclType.getSizeInBits();
     unsigned ElemNum = InVT.getVectorNumElements();
     EVT ResultType = EVT::getIntegerVT(*DAG.getContext(), InVT.getSizeInBits());
     EVT IntegerType = TLI.getVectorIdxTy();

--- a/lib/CodeGen/SelectionDAG/LegalizeTypes.h
+++ b/lib/CodeGen/SelectionDAG/LegalizeTypes.h
@@ -151,6 +151,7 @@ private:
   // Common routines.
   SDValue BitConvertToInteger(SDValue Op);
   SDValue BitConvertVectorToIntegerVector(SDValue Op);
+  SDValue CreateShiftOr(SDValue Op);
   SDValue CreateStackStoreLoad(SDValue Op, EVT DestVT);
   bool CustomLowerNode(SDNode *N, EVT VT, bool LegalizeResult);
   bool CustomWidenLowerNode(SDNode *N, EVT VT);
@@ -163,7 +164,7 @@ private:
   SDValue GetVectorElementPointer(SDValue VecPtr, EVT EltVT, SDValue Index);
   SDValue JoinIntegers(SDValue Lo, SDValue Hi);
   SDValue LibCallify(RTLIB::Libcall LC, SDNode *N, bool isSigned);
-  
+
   std::pair<SDValue, SDValue> ExpandChainLibCall(RTLIB::Libcall LC,
                                                  SDNode *Node, bool isSigned);
   std::pair<SDValue, SDValue> ExpandAtomic(SDNode *Node);


### PR DESCRIPTION
原先版本的bitcast遇到数组元素大小小于8的时候会出错，比如`bitcast <2 x i1><i1 0, i1 1> to i2`得到的结果不是2。现在的版本不会有这个问题了。

原来出错的原因也已经找到，我另开一个issue专门说一下。
