### PR TITLE
Legalize v32i1 and make use of pext in haswell

### DIFF
--- a/lib/CodeGen/SelectionDAG/LegalizeIntegerTypes.cpp
+++ b/lib/CodeGen/SelectionDAG/LegalizeIntegerTypes.cpp
@@ -979,6 +979,7 @@ SDValue DAGTypeLegalizer::PromoteIntOp_SCALAR_TO_VECTOR(SDNode *N) {
 }
 
 SDValue DAGTypeLegalizer::PromoteIntOp_SELECT(SDNode *N, unsigned OpNo) {
+    dbgs() << "In PromoteIntOp_SELECT.\n";
   assert(OpNo == 0 && "Only know how to promote the condition!");
   SDValue Cond = N->getOperand(0);
   EVT OpTy = N->getOperand(1).getValueType();

--- a/lib/Target/X86/X86CallingConv.td
+++ b/lib/Target/X86/X86CallingConv.td
@@ -37,6 +37,11 @@ def RetCC_X86Common : CallingConv<[
   CCIfType<[i32], CCAssignToReg<[EAX, EDX, ECX]>>,
   CCIfType<[i64], CCAssignToReg<[RAX, RDX, RCX]>>,
 
+  //My Edition
+  //Vector type v32i1 is stored in GR32Reg.
+  CCIfType<[v32i1], CCAssignToReg<[EAX, EDX, ECX]>>,
+  
+
   // Vector types are returned in XMM0 and XMM1, when they fit.  XMM2 and XMM3
   // can only be used by ABI non-compliant code. If the target doesn't have XMM
   // registers, it won't have vector types.
@@ -229,6 +234,10 @@ def CC_X86_64_C : CallingConv<[
   // The first 6 integer arguments are passed in integer registers.
   CCIfType<[i32], CCAssignToReg<[EDI, ESI, EDX, ECX, R8D, R9D]>>,
   CCIfType<[i64], CCAssignToReg<[RDI, RSI, RDX, RCX, R8 , R9 ]>>,
+
+  //My Edition
+  //Vector type v32i1 is stored in GR32Reg. 
+  CCIfType<[v32i1], CCAssignToReg<[EDI, ESI, EDX, ECX, R8D, R9D]>>,
 
   // The first 8 MMX vector arguments are passed in XMM registers on Darwin.
   CCIfType<[x86mmx],

--- a/lib/Target/X86/X86CallingConv.td
+++ b/lib/Target/X86/X86CallingConv.td
@@ -37,7 +37,6 @@ def RetCC_X86Common : CallingConv<[
   CCIfType<[i32], CCAssignToReg<[EAX, EDX, ECX]>>,
   CCIfType<[i64], CCAssignToReg<[RAX, RDX, RCX]>>,
 
-  //My Edition
   //Vector type v32i1 is stored in GR32Reg.
   CCIfType<[v32i1], CCAssignToReg<[EAX, EDX, ECX]>>,
   
@@ -235,7 +234,6 @@ def CC_X86_64_C : CallingConv<[
   CCIfType<[i32], CCAssignToReg<[EDI, ESI, EDX, ECX, R8D, R9D]>>,
   CCIfType<[i64], CCAssignToReg<[RDI, RSI, RDX, RCX, R8 , R9 ]>>,
 
-  //My Edition
   //Vector type v32i1 is stored in GR32Reg. 
   CCIfType<[v32i1], CCAssignToReg<[EDI, ESI, EDX, ECX, R8D, R9D]>>,
 

--- a/lib/Target/X86/X86ISelLowering.cpp
+++ b/lib/Target/X86/X86ISelLowering.cpp
@@ -2234,9 +2234,10 @@ X86TargetLowering::LowerFormalArguments(SDValue Chain,
         RC = &X86::VK8RegClass;
       else if (RegVT == MVT::v16i1)
         RC = &X86::VK16RegClass;
-      //My Edition
+
+      //Add to make v32i1 as argument available
       else if (RegVT == MVT::v32i1)
-          RC = &X86::GR32RegClass;
+          RC = &X86::VR32RegClass;
       else
         llvm_unreachable("Unknown argument type!");
 
@@ -3643,8 +3644,7 @@ static bool isPALIGNRMask(ArrayRef<int> Mask, MVT VT,
   if ((VT.is128BitVector() && !Subtarget->hasSSSE3()) ||
       (VT.is256BitVector() && !Subtarget->hasInt256()))
     return false;
-    dbgs() << __FILE__ << " " << __LINE__ << ".\n";
-    //Return false when VT's Bit Size is less than 128
+  //Return false when VT's Bit Size is less than 128
   if (VT.getSizeInBits() < 128)
     return false;
 
@@ -7328,7 +7328,6 @@ NormalizeVectorShuffle(SDValue Op, const X86Subtarget *Subtarget,
 
 SDValue
 X86TargetLowering::LowerVECTOR_SHUFFLE(SDValue Op, SelectionDAG &DAG) const {
-    dbgs() << "In LowerVector_SHUFFLE.\n";
   ShuffleVectorSDNode *SVOp = cast<ShuffleVectorSDNode>(Op);
   SDValue V1 = Op.getOperand(0);
   SDValue V2 = Op.getOperand(1);
@@ -7352,7 +7351,6 @@ X86TargetLowering::LowerVECTOR_SHUFFLE(SDValue Op, SelectionDAG &DAG) const {
     return DAG.getUNDEF(VT);
 
   assert(!V1IsUndef && "Op 1 of shuffle should not be undef");
-    dbgs() << __FILE__ << " " << __LINE__ << ".\n";
 
   // Vector shuffle lowering takes 3 steps:
   //
@@ -7377,7 +7375,6 @@ X86TargetLowering::LowerVECTOR_SHUFFLE(SDValue Op, SelectionDAG &DAG) const {
 
   SmallVector<int, 8> M(SVOp->getMask().begin(), SVOp->getMask().end());
 
-    dbgs() << __FILE__ << " " << __LINE__ << ".\n";
   // NOTE: isPSHUFDMask can also match both masks below (unpckl_undef and
   // unpckh_undef). Only use pshufd if speed is more important than size.
   if (OptForSize && isUNPCKL_v_undef_Mask(M, VT, HasInt256))
@@ -7391,7 +7388,6 @@ X86TargetLowering::LowerVECTOR_SHUFFLE(SDValue Op, SelectionDAG &DAG) const {
 
   if (isMOVHLPS_v_undef_Mask(M, VT))
     return getMOVHighToLow(Op, dl, DAG);
-    dbgs() << __FILE__ << " " << __LINE__ << ".\n";
 
   // Use to match splats
     //Chang the order because the isUNPCKHMask will raise error when
@@ -7400,7 +7396,6 @@ X86TargetLowering::LowerVECTOR_SHUFFLE(SDValue Op, SelectionDAG &DAG) const {
       HasSSE2 && isUNPCKHMask(M, VT, HasInt256) && V2IsUndef)
     return getTargetShuffleNode(X86ISD::UNPCKH, dl, VT, V1, V1, DAG);
 
-    dbgs() << __FILE__ << " " << __LINE__ << ".\n";
   if (isPSHUFDMask(M, VT)) {
     // The actual implementation will match the mask in the if above and then
     // during isel it can match several different instructions, not only pshufd
@@ -7421,13 +7416,11 @@ X86TargetLowering::LowerVECTOR_SHUFFLE(SDValue Op, SelectionDAG &DAG) const {
                                 TargetMask, DAG);
   }
 
-    dbgs() << __FILE__ << " " << __LINE__ << ".\n";
   if (isPALIGNRMask(M, VT, Subtarget))
     return getTargetShuffleNode(X86ISD::PALIGNR, dl, VT, V1, V2,
                                 getShufflePALIGNRImmediate(SVOp),
                                 DAG);
 
-    dbgs() << __FILE__ << " " << __LINE__ << ".\n";
   // Check if this can be converted into a logical shift.
   bool isLeft = false;
   unsigned ShAmt = 0;
@@ -7441,7 +7434,6 @@ X86TargetLowering::LowerVECTOR_SHUFFLE(SDValue Op, SelectionDAG &DAG) const {
     return getVShift(isLeft, VT, ShVal, ShAmt, DAG, *this, dl);
   }
 
-    dbgs() << __FILE__ << " " << __LINE__ << ".\n";
   if (isMOVLMask(M, VT)) {
     if (ISD::isBuildVectorAllZeros(V1.getNode()))
       return getVZextMovL(VT, VT, V2, DAG, Subtarget, dl);
@@ -7457,7 +7449,6 @@ X86TargetLowering::LowerVECTOR_SHUFFLE(SDValue Op, SelectionDAG &DAG) const {
   // FIXME: fold these into legal mask.
   if (isMOVLHPSMask(M, VT) && !isUNPCKLMask(M, VT, HasInt256))
     return getMOVLowToHigh(Op, dl, DAG, HasSSE2);
-    dbgs() << __FILE__ << " " << __LINE__ << ".\n";
 
   if (isMOVHLPSMask(M, VT))
     return getMOVHighToLow(Op, dl, DAG);
@@ -7467,7 +7458,6 @@ X86TargetLowering::LowerVECTOR_SHUFFLE(SDValue Op, SelectionDAG &DAG) const {
 
   if (V2IsUndef && isMOVSLDUPMask(M, VT, Subtarget))
     return getTargetShuffleNode(X86ISD::MOVSLDUP, dl, VT, V1, DAG);
-    dbgs() << __FILE__ << " " << __LINE__ << ".\n";
 
   if (isMOVLPMask(M, VT))
     return getMOVLP(Op, dl, DAG, HasSSE2);
@@ -7483,7 +7473,6 @@ X86TargetLowering::LowerVECTOR_SHUFFLE(SDValue Op, SelectionDAG &DAG) const {
     return getVShift(isLeft, VT, ShVal, ShAmt, DAG, *this, dl);
   }
 
-    dbgs() << __FILE__ << " " << __LINE__ << ".\n";
   bool Commuted = false;
   // FIXME: This should also accept a bitcast of a splat?  Be careful, not
   // 1,1,1,1 -> v8i16 though.
@@ -7671,7 +7660,6 @@ X86TargetLowering::LowerVECTOR_SHUFFLE(SDValue Op, SelectionDAG &DAG) const {
   // Handle general 256-bit shuffles
   if (VT.is256BitVector())
     return LowerVECTOR_SHUFFLE_256(SVOp, DAG);
-  dbgs() << "Gets end of LowerVECTOR_SHUFFLE.\n";
 
   return SDValue();
 }

--- a/lib/Target/X86/X86ISelLowering.cpp
+++ b/lib/Target/X86/X86ISelLowering.cpp
@@ -289,7 +289,7 @@ void X86TargetLowering::resetOperationActions() {
   addRegisterClass(MVT::i32, &X86::GR32RegClass);
 
   //My Edition
-  addRegisterClass(MVT::v32i1, &X86::GR32RegClass);
+  addRegisterClass(MVT::v32i1, &X86::VR32RegClass);
 
   if (Subtarget->is64Bit())
     addRegisterClass(MVT::i64, &X86::GR64RegClass);

--- a/lib/Target/X86/X86ISelLowering.cpp
+++ b/lib/Target/X86/X86ISelLowering.cpp
@@ -287,6 +287,10 @@ void X86TargetLowering::resetOperationActions() {
   addRegisterClass(MVT::i8, &X86::GR8RegClass);
   addRegisterClass(MVT::i16, &X86::GR16RegClass);
   addRegisterClass(MVT::i32, &X86::GR32RegClass);
+
+  //My Edition
+  addRegisterClass(MVT::v32i1, &X86::GR32RegClass);
+
   if (Subtarget->is64Bit())
     addRegisterClass(MVT::i64, &X86::GR64RegClass);
 
@@ -2226,6 +2230,9 @@ X86TargetLowering::LowerFormalArguments(SDValue Chain,
         RC = &X86::VK8RegClass;
       else if (RegVT == MVT::v16i1)
         RC = &X86::VK16RegClass;
+      //My Edition
+      else if (RegVT == MVT::v32i1)
+          RC = &X86::GR32RegClass;
       else
         llvm_unreachable("Unknown argument type!");
 

--- a/lib/Target/X86/X86ISelLowering.h
+++ b/lib/Target/X86/X86ISelLowering.h
@@ -881,6 +881,7 @@ namespace llvm {
                       SDLoc dl, SelectionDAG &DAG) const;
     SDValue LowerSETCC(SDValue Op, SelectionDAG &DAG) const;
     SDValue LowerSELECT(SDValue Op, SelectionDAG &DAG) const;
+    SDValue LowerVSELECT(SDValue Op, SelectionDAG &DAG) const;
     SDValue LowerBRCOND(SDValue Op, SelectionDAG &DAG) const;
     SDValue LowerMEMSET(SDValue Op, SelectionDAG &DAG) const;
     SDValue LowerJumpTable(SDValue Op, SelectionDAG &DAG) const;

--- a/lib/Target/X86/X86InstrInfo.td
+++ b/lib/Target/X86/X86InstrInfo.td
@@ -1917,6 +1917,12 @@ let Predicates = [HasBMI2] in {
                                int_x86_bmi_pext_64, loadi64>, T8XS, VEX_W;
 }
 
+//let Predicates = [HasBMI2] in {
+//  def : Pat <(v32i1 (bitconvert (i32 GR32:$src))), (v32i1 GR32:$src)>;
+  def : Pat <(i32 (bitconvert (v32i1 VR32:$src))), (i32 VR32:$src)>;
+  //def : Pat <(i64 (bitconvert (v64i1 GR64:$src))), (i64 GR64:$src)>;
+//}
+
 //===----------------------------------------------------------------------===//
 // TBM Instructions
 //

--- a/lib/Target/X86/X86InstrInfo.td
+++ b/lib/Target/X86/X86InstrInfo.td
@@ -1919,7 +1919,12 @@ let Predicates = [HasBMI2] in {
 
 //let Predicates = [HasBMI2] in {
 //  def : Pat <(v32i1 (bitconvert (i32 GR32:$src))), (v32i1 GR32:$src)>;
-  def : Pat <(i32 (bitconvert (v32i1 VR32:$src))), (i32 VR32:$src)>;
+def : Pat <(i32 (bitconvert (v32i1 VR32:$src))), (i32 VR32:$src)>;
+def : Pat <(i32 (bitconvert (v4i8 VR32:$src))), (i32 VR32:$src)>;
+def : Pat <(v4i8 (bitconvert (i32 VR32:$src))), (v4i8 VR32:$src)>;
+def : Pat <(v4i8 (bitconvert (v32i1 VR32:$src))), (v4i8 VR32:$src)>;
+def : Pat <(v32i1 (bitconvert (v4i8 VR32:$src))), (v32i1 VR32:$src)>;
+def : Pat <(v32i1 (bitconvert (i32 VR32:$src))), (v32i1 VR32:$src)>;
   //def : Pat <(i64 (bitconvert (v64i1 GR64:$src))), (i64 GR64:$src)>;
 //}
 

--- a/lib/Target/X86/X86RegisterInfo.td
+++ b/lib/Target/X86/X86RegisterInfo.td
@@ -432,6 +432,8 @@ def RST : RegisterClass<"X86", [f80, f64, f32], 32, (sequence "ST%u", 0, 7)> {
 }
 
 // Generic vector registers: VR64 and VR128.
+//TODO:
+def VR32: RegisterClass<"X86", [v32i1, i32], 32, (add GR32)>;
 def VR64: RegisterClass<"X86", [x86mmx], 64, (sequence "MM%u", 0, 7)>;
 def VR128 : RegisterClass<"X86", [v16i8, v8i16, v4i32, v2i64, v4f32, v2f64],
                           128, (add FR32)>;

--- a/lib/Target/X86/X86RegisterInfo.td
+++ b/lib/Target/X86/X86RegisterInfo.td
@@ -433,7 +433,7 @@ def RST : RegisterClass<"X86", [f80, f64, f32], 32, (sequence "ST%u", 0, 7)> {
 
 // Generic vector registers: VR64 and VR128.
 //TODO:
-def VR32: RegisterClass<"X86", [v32i1, i32], 32, (add GR32)>;
+def VR32: RegisterClass<"X86", [v32i1, i32, v4i8], 32, (add GR32)>;
 def VR64: RegisterClass<"X86", [x86mmx], 64, (sequence "MM%u", 0, 7)>;
 def VR128 : RegisterClass<"X86", [v16i8, v8i16, v4i32, v2i64, v4f32, v2f64],
                           128, (add FR32)>;

--- a/utils/TableGen/CodeGenDAGPatterns.cpp
+++ b/utils/TableGen/CodeGenDAGPatterns.cpp
@@ -225,8 +225,6 @@ bool EEVT::TypeSet::MergeInTypeInfo(const EEVT::TypeSet &InVT, TreePattern &TP){
   // If we removed all of our types, we have a type contradiction.
   if (!TypeVec.empty())
     return MadeChange;
-    //My Edition
-    dbgs() << __FILE__ << ":" << __LINE__ << "\n";
 
   // FIXME: Really want an SMLoc here!
   TP.error("Type inference contradiction found, merging '" +

--- a/utils/TableGen/CodeGenDAGPatterns.cpp
+++ b/utils/TableGen/CodeGenDAGPatterns.cpp
@@ -225,6 +225,8 @@ bool EEVT::TypeSet::MergeInTypeInfo(const EEVT::TypeSet &InVT, TreePattern &TP){
   // If we removed all of our types, we have a type contradiction.
   if (!TypeVec.empty())
     return MadeChange;
+    //My Edition
+    dbgs() << __FILE__ << ":" << __LINE__ << "\n";
 
   // FIXME: Really want an SMLoc here!
   TP.error("Type inference contradiction found, merging '" +


### PR DESCRIPTION
# Goal

I am working on legalizing type v32i1, and transforming vector_shuffle into pext operation in some specific masks. 
# How
1.  Legalize the type by addRegisterClass and edit file x86RegisterInfo.td to associate the type with proper register.
2. SetOperationAction to overwrite the default action of specific Operation with the type, like 
   `setOperationAction(ISD::VECTOR_SHUFFLE, MVT::v32i1, Custom);`
   If you want to use the `Custom` action, you need to check whether the `LowerOperation` function can support for the operation.
3.  Modified like the function `LowerVECTOR_SHUFFLE` to generate new node for the specific masks. 
   In some cases, need to change the `assertions`.
# Others

I just write a `VR32` for `v32i1` instead of using `GR32` directly, so that the `def : Pat <(i32 (bitconvert (v32i1 VR32:$src))), (i32 VR32:$src)>;` can be compiled successfully.
